### PR TITLE
Return dict instead of array on datapackage_registry.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,19 @@ custom_config = {
 }
 custom_registry = datapackage_registry.get(custom_config)
 
-# registry now has an array of dicts, e.g.:
-[{'id': 'base',
-  'schema': 'https://rawgit.com/dataprotocols/schemas/master/data-package.json',
-  'specification': 'http://dataprotocols.org/data-packages',
-  'title': 'Data Package'},
- {'id': 'tabular',
-  'schema': 'https://rawgit.com/dataprotocols/schemas/master/tabular-data-package.json',
-  'specification': 'http://dataprotocols.org/tabular-data-package/',
-  'title': 'Tabular Data Package'}]
-
+# registry now has a dict with each profile, mapped by the profile's id, e.g.:
+{
+    'base': {
+        'id': 'base',
+        'schema': 'https://rawgit.com/dataprotocols/schemas/master/data-package.json',
+        'specification': 'http://dataprotocols.org/data-packages',
+        'title': 'Data Package'
+    },
+    'tabular': {
+        'id': 'tabular',
+        'schema': 'https://rawgit.com/dataprotocols/schemas/master/tabular-data-package.json',
+        'specification': 'http://dataprotocols.org/tabular-data-package/',
+        'title': 'Tabular Data Package'
+   }
+}
 ```

--- a/datapackage_registry/registry.py
+++ b/datapackage_registry/registry.py
@@ -11,7 +11,7 @@ from . import compat
 
 
 DEFAULT_CONFIG = {
-  'backend': 'https://rawgit.com/dataprotocols/registry/master/registry.csv',
+    'backend': 'https://rawgit.com/dataprotocols/registry/master/registry.csv',
 }
 
 
@@ -28,7 +28,8 @@ def _get_registry_at_endpoint(endpoint):
 
 
 def get_registry(user_config=None):
-    '''Return the DataPackage Registry as an array of objects'''
+    '''Return the DataPackage Registry as a dict with profiles' ids as keys'''
     config = user_config or DEFAULT_CONFIG
 
-    return _get_registry_at_endpoint(config['backend'])
+    return dict([(profile['id'], profile)
+                 for profile in _get_registry_at_endpoint(config['backend'])])

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -23,17 +23,17 @@ class DataPackageRegistryGetTest(unittest.TestCase):
     '''Tests for registry.get()'''
 
     @httpretty.activate
-    def test_return_empty_array_when_registry_is_empty(self):
-        '''Return an empty array when registry csv is empty'''
+    def test_return_empty_dict_when_registry_is_empty(self):
+        '''Return an empty dict when registry csv is empty'''
         httpretty.register_uri(httpretty.GET, BACKEND_URL,
                                body="id,title,schema,specification")
 
-        assert_equal(datapackage_registry.get(), [],
-                     'Registry is not an empty array')
+        assert_equal(datapackage_registry.get(), {},
+                     'Registry is not an empty dict')
 
     @httpretty.activate
-    def test_return_non_empty_array_when_registry_is_not_empty(self):
-        '''Return an array of dicts when registry csv is not empty'''
+    def test_return_non_empty_dict_when_registry_is_not_empty(self):
+        '''Return an dict of dicts when registry csv is not empty'''
 
         body = """id,title,schema,specification
 base,Data Package,https://example.com/one.json,http://example.com
@@ -43,13 +43,13 @@ tabular,Tabular Data Package,https://example.com/two.json,http://example.com"""
 
         reg = datapackage_registry.get()
         assert_equal(len(reg), 2)
-        # each member in array is a dict
-        for o in reg:
+        # each profile in registry is a dict
+        for o in reg.values():
             assert_equal(type(o), dict)
 
     @httpretty.activate
     def test_dicts_have_expected_keys(self):
-        '''The returned dicts have the expected keys'''
+        '''The returned profiles have the expected keys'''
 
         body = """id,title,schema,specification
 base,Data Package,https://example.com/one.json,http://example.com
@@ -59,8 +59,8 @@ tabular,Tabular Data Package,https://example.com/two.json,http://example.com"""
 
         reg = datapackage_registry.get()
 
-        # each dict in array has the expected keys
-        for o in reg:
+        # each profile in registry has the expected keys
+        for o in reg.values():
             assert_true('id' in o)
             assert_true('title' in o)
             assert_true('schema' in o)
@@ -68,7 +68,7 @@ tabular,Tabular Data Package,https://example.com/two.json,http://example.com"""
 
     @httpretty.activate
     def test_dicts_have_expected_values(self):
-        '''The returned dicts have the expected values'''
+        '''The returned profiles have the expected values'''
 
         body = """id,title,schema,specification
 base,Data Package,https://example.com/one.json,http://example.com
@@ -77,12 +77,13 @@ tabular,Tabular Data Package,https://example.com/two.json,http://example.com"""
         httpretty.register_uri(httpretty.GET, BACKEND_URL, body=body)
 
         reg = datapackage_registry.get()
+        profile = reg['base']
 
-        # first dict in array has the expected values
-        assert_equal(reg[0]['id'], 'base')
-        assert_equal(reg[0]['title'], 'Data Package')
-        assert_equal(reg[0]['schema'], 'https://example.com/one.json')
-        assert_equal(reg[0]['specification'], 'http://example.com')
+        # first profile in registry has the expected values
+        assert_equal(profile['id'], 'base')
+        assert_equal(profile['title'], 'Data Package')
+        assert_equal(profile['schema'], 'https://example.com/one.json')
+        assert_equal(profile['specification'], 'http://example.com')
 
     @httpretty.activate
     def test_custom_config_returns_expected_values(self):
@@ -106,11 +107,12 @@ a,b,c,d"""
         }
 
         reg = datapackage_registry.get(custom_config)
+        profile = reg['1']
         assert_equal(len(reg), 2)
-        assert_equal(reg[0]['id'], '1')
-        assert_equal(reg[0]['title'], '2')
-        assert_equal(reg[0]['schema'], '3')
-        assert_equal(reg[0]['specification'], '4')
+        assert_equal(profile['id'], '1')
+        assert_equal(profile['title'], '2')
+        assert_equal(profile['schema'], '3')
+        assert_equal(profile['specification'], '4')
 
     @httpretty.activate
     def test_unicode_in_registry(self):
@@ -122,9 +124,10 @@ a,b,c,d"""
                                body=body)
 
         reg = datapackage_registry.get()
+        profile = reg['base']
         assert_equal(len(reg), 2)
-        assert_equal(reg[0]['id'], 'base')
-        assert_equal(reg[0]['title'], 'Iñtërnâtiônàlizætiøn')
+        assert_equal(profile['id'], 'base')
+        assert_equal(profile['title'], 'Iñtërnâtiônàlizætiøn')
 
     @httpretty.activate
     def test_404_raises_error(self):


### PR DESCRIPTION
I think the main use case for the registry is to get a schema data based on its `id`. Currently, to do this with `datapackage_registry.get()`, the user has to do:

```python
import datapackage_registry

registry = datapackage_registry.get()
base_schema = [schema for schema in registry
               if schema['id'] == 'base']
```

This involves quite a bit of boilerplate. It would be better to change that to:
```python
import datapackage_registry

registry = datapackage_registry.get()
base_schema = registry.get('base')
```